### PR TITLE
Include receipt in InvalidReceipt exception if available

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,8 +37,9 @@ Verification policy
 Set verification mode for production or sandbox api. Review mode also available for appstore review.
 
     >>> from itunesiap import Request
+    >>> request = Request(raw_data)
     >>> with request.verification_mode('review'): # enable both production and sandbox for appstore review. 'production', 'sandbox' or 'review'
-    >>>     receipt = Request(raw_data).verify()
+    >>>     receipt = request.verify()
 
 Workflow Shortcut
 -----------------

--- a/itunesiap/core.py
+++ b/itunesiap/core.py
@@ -64,7 +64,7 @@ class Request(object):
         self.result = self._extract_receipt(json.loads(self.response.content))
         status = self.result['status']
         if status != 0:
-            raise exceptions.InvalidReceipt(status)
+            raise exceptions.InvalidReceipt(status, receipt=self.result.get('receipt', None))
         return self.result
 
     def _extract_receipt(self, receipt_data):


### PR DESCRIPTION
It would be of value to include the receipt in the InvalidReceipt exception, particularly in the case of 21006 it would be nice to still be able to examine the receipt when handling the exception, even if it has been expired.  So this is just a minor contribution towards that...

thanks!