### PR TITLE
get latest in app purchase transaction

### DIFF
--- a/itunesiap/core.py
+++ b/itunesiap/core.py
@@ -72,7 +72,7 @@ class Request(object):
         """
         in_app_purchase = receipt_data['receipt'].get('in_app', [])
         if len(in_app_purchase) > 0:
-            receipt_data['receipt'].update(in_app_purchase[0])
+            receipt_data['receipt'].update(in_app_purchase[-1])
         return receipt_data
 
     def validate(self):


### PR DESCRIPTION
You will get a list from receipt 'in_app' key.
If there is any unfinished transaction, the length of this list may be > 1.
If so, the first item in list is the oldest transaction, the last item is the latest transaction.
So I change slice from 0 to -1 to get the latest transaction info, not the oldest.