### PR TITLE
Proposed bugfix for calling response.receipt.in_app resulting in an error

### DIFF
--- a/itunesiap/receipt.py
+++ b/itunesiap/receipt.py
@@ -59,7 +59,7 @@ class Receipt(ObjectMapper):
     @lazy_property
     def in_app(self):
         if 'in_app' in self._:
-            return map(self._in_app, InApp)
+            return map(InApp, self._in_app)
         else:
             return [InApp(self._)]
 

--- a/itunesiap/receipt.py
+++ b/itunesiap/receipt.py
@@ -59,7 +59,7 @@ class Receipt(ObjectMapper):
     @lazy_property
     def in_app(self):
         if 'in_app' in self._:
-            return map(InApp, self._in_app)
+            return list(map(InApp, self._in_app))
         else:
             return [InApp(self._)]
 

--- a/tests/v2_test.py
+++ b/tests/v2_test.py
@@ -181,6 +181,19 @@ def test_receipt():
 
     assert response.status == 0  # 0 is normal
 
+    # get the in_app property from the respnse
+    in_app = response.receipt.in_app
+    assert len(in_app) == 2
+
+    # test that the InApp object was setup correctly
+    in_app0 = in_app[0]
+    assert in_app0.product_id == u'org.itunesiap'
+    assert in_app0.original_transaction_id == u'1000000155715958'
+    assert in_app0.quantity == 1
+
+    # and that the last_in_app alias is set up correctly
+    assert response.receipt.last_in_app == in_app[-1]
+
 
 def test_shortcut():
     """Test shortcuts"""


### PR DESCRIPTION
This pull request provides a proposed solution for calling response.receipt.in_app in the new receipt format.  It also produces a uniform return type for python2 and python3