### PR TITLE
Add in_app to white list

### DIFF
--- a/itunesiap/receipt.py
+++ b/itunesiap/receipt.py
@@ -53,7 +53,7 @@ class Response(ObjectMapper):
 
 
 class Receipt(ObjectMapper):
-    __WHITELIST__ = []
+    __WHITELIST__ = ['in_app']
     __EXPORT_FILTERS__ = {}
 
     @lazy_property


### PR DESCRIPTION
Removes warning caused by the object mapper when
trying to request a unknown property.