### PR TITLE
Proposal for encapsulating requests errors and provide user option for verifing ssl certs

### DIFF
--- a/itunesiap/receipt.py
+++ b/itunesiap/receipt.py
@@ -72,7 +72,8 @@ class Receipt(ObjectMapper):
 
 def json_bool_to_native(data):
     assert data in ('true', 'false'), \
-        "Cannot convert {0}, acceptable values are 'true' and 'false'".format(data)
+            ("Cannot convert {0}, "
+            "acceptable values are true' and 'false'".format(data))
     return json.loads(data)
 
 

--- a/itunesiap/receipt.py
+++ b/itunesiap/receipt.py
@@ -77,7 +77,7 @@ def json_bool_to_native(data):
 
 
 class InApp(ObjectMapper):
-    __WHITELIST__ = ['quantity', 'product_id', 'transaction_id', 'original_transaction_id', 'purchase_date', 'original_purchase_date', 'expires_date', 'cancellation_date', 'is_trial_period', u'original_purchase_date_ms', u'purchase_date_ms']
+    __WHITELIST__ = ['quantity', 'product_id', 'transaction_id', 'original_transaction_id', 'purchase_date', 'original_purchase_date', 'expires_date', 'cancellation_date', 'is_trial_period', 'original_purchase_date_ms', 'purchase_date_ms']
     __EXPORT_FILTERS__ = {
         'quantity': int,
         'is_trial_period': json_bool_to_native,

--- a/itunesiap/receipt.py
+++ b/itunesiap/receipt.py
@@ -72,8 +72,8 @@ class Receipt(ObjectMapper):
 
 def json_bool_to_native(data):
     assert data in ('true', 'false'), \
-            ("Cannot convert {0}, "
-            "acceptable values are true' and 'false'".format(data))
+        ("Cannot convert {0}, "
+         "acceptable values are true' and 'false'".format(data))
     return json.loads(data)
 
 

--- a/itunesiap/receipt.py
+++ b/itunesiap/receipt.py
@@ -1,5 +1,7 @@
 
 import warnings
+import json
+
 from .tools import lazy_property
 
 
@@ -68,8 +70,17 @@ class Receipt(ObjectMapper):
         return self.in_app[-1]
 
 
+def json_bool_to_native(data):
+    assert data in ('true', 'false'), \
+        "Cannot convert {0}, acceptable values are 'true' and 'false'".format(data)
+    return json.loads(data)
+
+
 class InApp(ObjectMapper):
-    __WHITELIST__ = ['quantity', 'product_id', 'transaction_id', 'original_transaction_id', 'purchase_date', 'original_purchase_date', 'expires_date', 'cancellation_date']
+    __WHITELIST__ = ['quantity', 'product_id', 'transaction_id', 'original_transaction_id', 'purchase_date', 'original_purchase_date', 'expires_date', 'cancellation_date', 'is_trial_period', u'original_purchase_date_ms', u'purchase_date_ms']
     __EXPORT_FILTERS__ = {
         'quantity': int,
+        'is_trial_period': json_bool_to_native,
+        'original_purchase_date_ms': int,
+        'purchase_date_ms': int,
     }

--- a/itunesiap/request.py
+++ b/itunesiap/request.py
@@ -35,9 +35,12 @@ class Request(object):
     def verify_from(self, url):
         """Try verification from given url."""
         # If the password exists from kwargs, pass it up with the request, otherwise leave it alone
-        http_response = requests.post(url, json.dumps(self.request_content), verify=False)
-        if http_response.status_code != 200:
-            raise exceptions.ItunesServerNotAvailable(http_response.status_code, http_response.content)
+        try:
+            http_response = requests.post(url, json.dumps(self.request_content))
+            if http_response.status_code != 200:
+                raise exceptions.ItunesServerNotAvailable(http_response.status_code, http_response.content)
+        except requests.exceptions.RequestException as e:
+            raise exceptions.RequestError('There was a {0} error while performing the request'.format(type(e)))
 
         response = receipt.Response(json.loads(http_response.content.decode('utf-8')))
         if response.status != 0:

--- a/itunesiap/request.py
+++ b/itunesiap/request.py
@@ -40,7 +40,7 @@ class Request(object):
             if http_response.status_code != 200:
                 raise exceptions.ItunesServerNotAvailable(http_response.status_code, http_response.content)
         except requests.exceptions.RequestException as e:
-            raise exceptions.RequestError('There was a {0} error while performing the request'.format(type(e)))
+            raise exceptions.RequestError('There was an error performing the request', e)
 
         response = receipt.Response(json.loads(http_response.content.decode('utf-8')))
         if response.status != 0:

--- a/itunesiap/request.py
+++ b/itunesiap/request.py
@@ -32,11 +32,11 @@ class Request(object):
             request_content = {'receipt-data': self.receipt_data}
         return request_content
 
-    def verify_from(self, url):
+    def verify_from(self, url, verify_request):
         """Try verification from given url."""
         # If the password exists from kwargs, pass it up with the request, otherwise leave it alone
         try:
-            http_response = requests.post(url, json.dumps(self.request_content))
+            http_response = requests.post(url, json.dumps(self.request_content), verify=verify_request)
             if http_response.status_code != 200:
                 raise exceptions.ItunesServerNotAvailable(http_response.status_code, http_response.content)
         except requests.exceptions.RequestException as e:
@@ -47,8 +47,11 @@ class Request(object):
             raise exceptions.InvalidReceipt(response.status, response=response)
         return response
 
-    def verify(self):
+    def verify(self, verify_request=False):
         """Try verification with current environment.
+        If verify_request is true, Apple's SSL certificiate will be
+        verified. The verify_request is set to false by default for
+        backwards compatability.
 
         Returns a `Receipt` object if succeed. Otherwise raise an exception.
         """
@@ -59,13 +62,13 @@ class Request(object):
         e = None
         if env.use_production:
             try:
-                response = self.verify_from(RECEIPT_PRODUCTION_VALIDATION_URL)
+                response = self.verify_from(RECEIPT_PRODUCTION_VALIDATION_URL, verify_request)
             except exceptions.InvalidReceipt as ee:
                 e = ee
 
         if not response and env.use_sandbox:
             try:
-                response = self.verify_from(RECEIPT_SANDBOX_VALIDATION_URL)
+                response = self.verify_from(RECEIPT_SANDBOX_VALIDATION_URL, verify_request)
             except exceptions.InvalidReceipt as ee:
                 if not env.use_production:
                     e = ee

--- a/tests/v2_test.py
+++ b/tests/v2_test.py
@@ -128,8 +128,9 @@ def test_request_fail():
         try:
             request.verify()
             assert False
-        except itunesiap.exc.RequestError:
-            assert True
+        except itunesiap.exc.RequestError as e:
+            assert type(e.args[1]) == requests.exceptions.ReadTimeout
+
 
 
 @pytest.mark.parametrize("sandbox_receipt", [LEGACY_RAW_RECEIPT])

--- a/tests/v2_test.py
+++ b/tests/v2_test.py
@@ -191,7 +191,7 @@ def test_receipt():
     assert in_app0.original_transaction_id == u'1000000155715958'
     assert in_app0.quantity == 1
     assert isinstance(in_app0.is_trial_period, bool)
-    assert not in_app0.is_trial_period # is_trial_period is false
+    assert not in_app0.is_trial_period  # is_trial_period is false
     assert isinstance(in_app0.original_purchase_date_ms, int)
     assert in_app0.original_purchase_date_ms == 1432002585000
     assert isinstance(in_app0.purchase_date_ms, int)

--- a/tests/v2_test.py
+++ b/tests/v2_test.py
@@ -119,6 +119,19 @@ def test_itunes_not_available():
             assert e.args[1] == 'Not avaliable'
 
 
+def test_request_fail():
+    """Test failure making request to itunes server """
+    # We're going to return an invalid http status code
+    with patch.object(requests, 'post') as mock_post:
+        mock_post.side_effect = requests.exceptions.ReadTimeout('Timeout')
+        request = itunesiap.Request('DummyReceipt')
+        try:
+            request.verify()
+            assert False
+        except itunesiap.exc.RequestError:
+            assert True
+
+
 @pytest.mark.parametrize("sandbox_receipt", [LEGACY_RAW_RECEIPT])
 def test_context(sandbox_receipt):
     """Test sandbox receipts with real itunes server."""

--- a/tests/v2_test.py
+++ b/tests/v2_test.py
@@ -132,6 +132,18 @@ def test_request_fail():
             assert type(e.args[1]) == requests.exceptions.ReadTimeout
 
 
+def test_ssl_request_fail():
+    """Test failure making request to itunes server """
+    # We're going to return an invalid http status code
+    with patch.object(requests, 'post') as mock_post:
+        mock_post.side_effect = requests.exceptions.SSLError('Bad ssl')
+        request = itunesiap.Request('DummyReceipt')
+        try:
+            request.verify(verify_request=True)
+            assert False
+        except itunesiap.exc.RequestError as e:
+            assert type(e.args[1]) == requests.exceptions.SSLError
+
 
 @pytest.mark.parametrize("sandbox_receipt", [LEGACY_RAW_RECEIPT])
 def test_context(sandbox_receipt):

--- a/tests/v2_test.py
+++ b/tests/v2_test.py
@@ -190,6 +190,12 @@ def test_receipt():
     assert in_app0.product_id == u'org.itunesiap'
     assert in_app0.original_transaction_id == u'1000000155715958'
     assert in_app0.quantity == 1
+    assert isinstance(in_app0.is_trial_period, bool)
+    assert not in_app0.is_trial_period # is_trial_period is false
+    assert isinstance(in_app0.original_purchase_date_ms, int)
+    assert in_app0.original_purchase_date_ms == 1432002585000
+    assert isinstance(in_app0.purchase_date_ms, int)
+    assert in_app0.purchase_date_ms == 1432005669000
 
     # and that the last_in_app alias is set up correctly
     assert response.receipt.last_in_app == in_app[-1]


### PR DESCRIPTION
The original goal was to all the user to specify an option for verifying ssl certs.   (relevant to issue #16)

In the process, I ended up encapsulating the requests errors within itunes-iap.