### PR TITLE
Make ObjectMapper inner dictionary writable

### DIFF
--- a/itunesiap/receipt.py
+++ b/itunesiap/receipt.py
@@ -53,6 +53,9 @@ class ObjectMapper(object):
     def __getitem__(self, item):
         return self._[item]
 
+    def __setitem__(self, key, value):
+        self._[key] = value
+
     def __getattr__(self, item):
         try:
             return super(ObjectMapper, self).__getattr__(item)


### PR DESCRIPTION
Simplifies mocking of itunes receipt for unit testing. E.g.:

```python
response = Response('json')
response.receipt.last_in_app['expires_date'] = 'expected date'
mock_verify.return_value = response
```