### PR TITLE
Allows access iTunes Validation URL through proxy 

### DIFF
--- a/itunesiap/request.py
+++ b/itunesiap/request.py
@@ -50,8 +50,8 @@ class Request(object):
         post_body = json.dumps(self.request_content)
         try:
             if self.proxy_url:
-                proxy_url = "https://" + self.proxy_url
-                http_response = requests.post(url, post_body, verify=verify_ssl, proxies={'https': proxy_url})
+                protocol = self.proxy_url.split('://')[0]
+                http_response = requests.post(url, post_body, verify=verify_ssl, proxies={protocol: self.proxy_url})
             else:
                 http_response = requests.post(url, post_body, verify=verify_ssl)
         except requests.exceptions.RequestException as e:

--- a/itunesiap/request.py
+++ b/itunesiap/request.py
@@ -17,11 +17,13 @@ class Request(object):
     Use `verify` method to try verification and get Receipt or exception.
 
     :param str receipt_data: An iTunes receipt data as Base64 encoded string.
+    :param proxy_url: A proxy url to access the itunes validation url
     """
 
-    def __init__(self, receipt_data, password=None):
+    def __init__(self, receipt_data, password=None, proxy_url=None):
         self.receipt_data = receipt_data
         self.password = password
+        self.proxy_url = proxy_url
 
     def __repr__(self):
         return u'<Request({1}...)>'.format(self.receipt_data[:20])
@@ -47,7 +49,11 @@ class Request(object):
         # If the password exists from kwargs, pass it up with the request, otherwise leave it alone
         post_body = json.dumps(self.request_content)
         try:
-            http_response = requests.post(url, post_body, verify=verify_ssl)
+            if self.proxy_url:
+                proxy_url = "https://" + self.proxy_url
+                http_response = requests.post(url, post_body, verify=verify_ssl, proxies={'https': proxy_url})
+            else:
+                http_response = requests.post(url, post_body, verify=verify_ssl)
         except requests.exceptions.RequestException as e:
             raise exceptions.ItunesServerNotReachable(exc=e)
 

--- a/itunesiap/shortcut.py
+++ b/itunesiap/shortcut.py
@@ -2,10 +2,11 @@
 from .request import Request
 
 
-def verify(receipt_data, password=None, **kwargs):
+def verify(receipt_data, password=None, proxy_url=None, **kwargs):
     """Shortcut API for :class:`itunesiap.request.Request`
 
     :param str receipt_data: An iTunes receipt data as Base64 encoded string.
+    :param proxy_url: A proxy url to access the itunes validation url
     :param bool use_production: Override environment value if given
     :param bool use_sandbox: Override environment value if given
     :param bool verify_ssl: Override environment value if given
@@ -13,4 +14,4 @@ def verify(receipt_data, password=None, **kwargs):
     :return: :class:`itunesiap.receipt.Receipt` object if succeed.
     :raises: Otherwise raise a request exception.
     """
-    return Request(receipt_data, password).verify(**kwargs)
+    return Request(receipt_data, password, proxy_url).verify(**kwargs)


### PR DESCRIPTION
In my work environments the server has no internet access, so is necessary to access external urls with proxy.