### PR TITLE
Failback to sandbox only on specific status

### DIFF
--- a/itunesiap/request.py
+++ b/itunesiap/request.py
@@ -91,7 +91,7 @@ class Request(object):
                 response = self.verify_from(RECEIPT_PRODUCTION_VALIDATION_URL, verify_ssl)
             except exceptions.InvalidReceipt:
                 if not use_sandbox and (response is None or
-                        response.status != STATUS_SANDBOX_RECEIPT_ERROR):
+                                        response.status != STATUS_SANDBOX_RECEIPT_ERROR):
                     raise
 
         if not response and use_sandbox:

--- a/itunesiap/request.py
+++ b/itunesiap/request.py
@@ -89,9 +89,8 @@ class Request(object):
         if use_production:
             try:
                 response = self.verify_from(RECEIPT_PRODUCTION_VALIDATION_URL, verify_ssl)
-            except exceptions.InvalidReceipt:
-                if not use_sandbox and (response is None or
-                                        response.status != STATUS_SANDBOX_RECEIPT_ERROR):
+            except exceptions.InvalidReceipt as e:
+                if not use_sandbox or e.status != STATUS_SANDBOX_RECEIPT_ERROR:
                     raise
 
         if not response and use_sandbox:

--- a/itunesiap/request.py
+++ b/itunesiap/request.py
@@ -9,6 +9,7 @@ from .environment import Environment
 
 RECEIPT_PRODUCTION_VALIDATION_URL = "https://buy.itunes.apple.com/verifyReceipt"
 RECEIPT_SANDBOX_VALIDATION_URL = "https://sandbox.itunes.apple.com/verifyReceipt"
+STATUS_SANDBOX_RECEIPT_ERROR = 21007
 
 
 class Request(object):
@@ -89,7 +90,8 @@ class Request(object):
             try:
                 response = self.verify_from(RECEIPT_PRODUCTION_VALIDATION_URL, verify_ssl)
             except exceptions.InvalidReceipt:
-                if not use_sandbox:
+                if not use_sandbox and (response is None or
+                        response.status != STATUS_SANDBOX_RECEIPT_ERROR):
                     raise
 
         if not response and use_sandbox:


### PR DESCRIPTION
According to iTunes documentation, their production API will return specific status in case when we are sending transaction raw data from their sandbox's environment:
https://developer.apple.com/library/ios/technotes/tn2413/_index.html#//apple_ref/doc/uid/DTS40016228-CH1-RECEIPTURL

Hence, we do not need to send any other failed transactions (those which returned status other than 21007) to sandbox in case when both production and sandbox environments are used.


Note: while testing on my machine (excluding py2.6, 3.3 and pypi) I got FAIL for py27 in test_receipt, line `assert isinstance(in_app0.original_purchase_date_ms, int)` - 1432002585000L is not an int (if applicable, I'm using 32bit OS).