### PR TITLE
by-AttributeError/KeyError-catchable ObjectMapper attribute misses

### DIFF
--- a/itunesiap/exceptions.py
+++ b/itunesiap/exceptions.py
@@ -30,3 +30,7 @@ class InvalidReceipt(RequestError):
     @property
     def description(self):
         return self._descriptions.get(self.status, None)
+
+
+class MissingFieldError(E, AttributeError, KeyError):
+    pass

--- a/itunesiap/receipt.py
+++ b/itunesiap/receipt.py
@@ -4,6 +4,7 @@ import dateutil.parser
 import warnings
 import json
 
+from .exceptions import MissingFieldError
 from .tools import lazy_property
 
 
@@ -57,16 +58,19 @@ class ObjectMapper(object):
         try:
             return super(ObjectMapper, self).__getattr__(item)
         except AttributeError:
-            if item.startswith('_'):
-                key = item[1:]
-                if key not in self.__WHITELIST__:
-                    warnings.warn('Given key `{0}` is not in __WHITELIST__. It maybe a wrong key. Check raw data `_` for real receipt data.'.format(key))
-                return self._[key]
-            if item in self.__EXPORT_FILTERS__:
-                filter = self.__EXPORT_FILTERS__[item]
-                return filter(self._[item])
-            if item in self.__WHITELIST__:
-                return self._[item]
+            try:
+                if item.startswith('_'):
+                    key = item[1:]
+                    if key not in self.__WHITELIST__:
+                        warnings.warn('Given key `{0}` is not in __WHITELIST__. It maybe a wrong key. Check raw data `_` for real receipt data.'.format(key))
+                    return self._[key]
+                if item in self.__EXPORT_FILTERS__:
+                    filter = self.__EXPORT_FILTERS__[item]
+                    return filter(self._[item])
+                if item in self.__WHITELIST__:
+                    return self._[item]
+            except KeyError:
+                raise MissingFieldError(item)
             return super(ObjectMapper, self).__getattribute__(item)
 
 

--- a/tests/itunesiap_test.py
+++ b/tests/itunesiap_test.py
@@ -244,6 +244,12 @@ def test_receipt():
     # and that the last_in_app alias is set up correctly
     assert response.receipt.last_in_app == in_app[-1]
 
+    with pytest.raises(AttributeError):
+        response.receipt.in_app[0].expires_date
+    with pytest.raises(KeyError):
+        response.receipt.in_app[0].expires_date
+        # ensure we can also catch this with KeyError due to backward compatibility
+
 
 def test_shortcut():
     """Test shortcuts"""


### PR DESCRIPTION
Motivation:
* KeyError from attribute access is unexpectable.

Changes:
* Raise other exception could be caught by AttributeError, rather than KeyError.
* To prevent unintended breaking on codes may be using KeyError to catch that cases, created MissingFieldError inherited both AttributeError and KeyError.