### PR TITLE
expires_date_formatted

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ MANIFEST
 .ropeproject
 .coveralls.yml
 .coverage
+.DS_Store

--- a/itunesiap/receipt.py
+++ b/itunesiap/receipt.py
@@ -111,13 +111,14 @@ class InApp(ObjectMapper):
     __WHITELIST__ = [
         'quantity', 'product_id', 'transaction_id', 'original_transaction_id', 'is_trial_period',
         'purchase_date', 'original_purchase_date', 'expires_date', 'cancellation_date',
-        'purchase_date_ms', 'original_purchase_date_ms', 'expires_date_ms', 'cancellation_date_ms']
+        'purchase_date_ms', 'original_purchase_date_ms', 'expires_date_ms', 'cancellation_date_ms', 'expires_date_formatted',]
     __EXPORT_FILTERS__ = {
         'quantity': int,
         'is_trial_period': _to_bool,
         'purchase_date': _to_datetime,
         'original_purchase_date': _to_datetime,
         'expires_date': _to_datetime,
+        'expires_date_formatted': _to_datetime,
         'cancellation_date': _to_datetime,
         'purchase_date_ms': int,
         'original_purchase_date_ms': int,


### PR DESCRIPTION
In my application, I have found that the iTunes receipt response object (InApp) does not contain 'expires_date', but rather 'expires_date_formatted'.  This can also be parsed by '_to_datetime', so I have simply added it to the InApp object __EXPORT_FILTERS__ dict.

Also added .DS_Store to .gitignore because Mac.