### PR TITLE
Add an enivronment property to repsonse

### DIFF
--- a/itunesiap/receipt.py
+++ b/itunesiap/receipt.py
@@ -90,6 +90,13 @@ class Response(ObjectMapper):
     def latest_receipt(self):
         return Receipt(self._latest_receipt)
 
+    @property
+    def env(self):
+        return self._['env'] if 'env' in self._ else ''
+
+    @env.setter
+    def env(self, value):
+        self._['env'] = value
 
 class Receipt(ObjectMapper):
     __WHITELIST__ = ['in_app']

--- a/itunesiap/request.py
+++ b/itunesiap/request.py
@@ -89,6 +89,7 @@ class Request(object):
         if use_production:
             try:
                 response = self.verify_from(RECEIPT_PRODUCTION_VALIDATION_URL, verify_ssl)
+                response.env = 'production'
             except exceptions.InvalidReceipt as e:
                 if not use_sandbox or e.status != STATUS_SANDBOX_RECEIPT_ERROR:
                     raise
@@ -96,6 +97,7 @@ class Request(object):
         if not response and use_sandbox:
             try:
                 response = self.verify_from(RECEIPT_SANDBOX_VALIDATION_URL, verify_ssl)
+                response.env = 'sandbox'
             except exceptions.InvalidReceipt:
                 raise
 

--- a/itunesiap/request.py
+++ b/itunesiap/request.py
@@ -21,10 +21,11 @@ class Request(object):
     :param proxy_url: A proxy url to access the itunes validation url
     """
 
-    def __init__(self, receipt_data, password=None, proxy_url=None):
+    def __init__(self, receipt_data, password=None, proxy_url=None, timeout=60):
         self.receipt_data = receipt_data
         self.password = password
         self.proxy_url = proxy_url
+        self.timeout = timeout
 
     def __repr__(self):
         return u'<Request({0}...)>'.format(self.receipt_data[:20])
@@ -52,9 +53,9 @@ class Request(object):
         try:
             if self.proxy_url:
                 protocol = self.proxy_url.split('://')[0]
-                http_response = requests.post(url, post_body, verify=verify_ssl, proxies={protocol: self.proxy_url})
+                http_response = requests.post(url, post_body, verify=verify_ssl, proxies={protocol: self.proxy_url}, timeout=self.timeout)
             else:
-                http_response = requests.post(url, post_body, verify=verify_ssl)
+                http_response = requests.post(url, post_body, verify=verify_ssl, timeout=self.timeout)
         except requests.exceptions.RequestException as e:
             raise exceptions.ItunesServerNotReachable(exc=e)
 

--- a/itunesiap/shortcut.py
+++ b/itunesiap/shortcut.py
@@ -2,7 +2,7 @@
 from .request import Request
 
 
-def verify(receipt_data, password=None, proxy_url=None, **kwargs):
+def verify(receipt_data, password=None, proxy_url=None, timeout=60, **kwargs):
     """Shortcut API for :class:`itunesiap.request.Request`
 
     :param str receipt_data: An iTunes receipt data as Base64 encoded string.
@@ -14,4 +14,4 @@ def verify(receipt_data, password=None, proxy_url=None, **kwargs):
     :return: :class:`itunesiap.receipt.Receipt` object if succeed.
     :raises: Otherwise raise a request exception.
     """
-    return Request(receipt_data, password, proxy_url).verify(**kwargs)
+    return Request(receipt_data, password, proxy_url, timeout).verify(**kwargs)


### PR DESCRIPTION
Sometimes, it is needed to know where the response come from, especially when env.review is used.
