### PR TITLE
On python 3.4 asyncio.coroutines will traceback with AttributeError …

### DIFF
--- a/itunesiap/request.py
+++ b/itunesiap/request.py
@@ -4,7 +4,7 @@ from itunesiap.verify_requests import RequestsVerify
 
 try:
     from itunesiap.verify_aiohttp import AiohttpVerify
-except (SyntaxError, ImportError):  # pragma: no cover
+except (SyntaxError, ImportError, AttributeError):  # pragma: no cover
     class AiohttpVerify(object):
         pass
 


### PR DESCRIPTION
…so use the alternative requests.

Traceback (most recent call last): 
  File "/home/silver/.local/share/virtualenvs/silver/lib/python3.4/site-packages/my_project/iap.py", line 6, in <module> 
    import itunesiap 
  File "/home/silver/.local/share/virtualenvs/silver/lib/python3.4/site-packages/itunesiap/__init__.py", line 13, in <module> 
    from .request import Request 
  File "/home/silver/.local/share/virtualenvs/silver/lib/python3.4/site-packages/itunesiap/request.py", line 6, in <module> 
    from itunesiap.verify_aiohttp import AiohttpVerify 
  File "/home/silver/.local/share/virtualenvs/silver/lib/python3.4/site-packages/itunesiap/verify_aiohttp.py", line 3, in <module> 
    import aiohttp 
  File "/home/silver/.local/share/virtualenvs/silver/lib/python3.4/site-packages/aiohttp/__init__.py", line 6, in <module> 
    from .client import *  # noqa 
  File "/home/silver/.local/share/virtualenvs/silver/lib/python3.4/site-packages/aiohttp/client.py", line 15, in <module> 
    from . import connector as connector_mod 
  File "/home/silver/.local/share/virtualenvs/silver/lib/python3.4/site-packages/aiohttp/connector.py", line 13, in <module> 
    from . import hdrs, helpers 
  File "/home/silver/.local/share/virtualenvs/silver/lib/python3.4/site-packages/aiohttp/helpers.py", line 142, in <module> 
    coroutines = asyncio.coroutines 
AttributeError: 'module' object has no attribute 'coroutines' 
