### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ tests_require = [
     'pytest>=3.0.0', 'pytest-cov', 'tox', 'mock', 'patch',
 ]
 
-if sys.version_info[:2] >= (3, 5, 3):
+if sys.version_info[:3] >= (3, 5, 3):
     install_requires.extend([
         'aiohttp>=3.0.1', 'aiodns>=1.1.1',
     ])

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ tests_require = [
     'pytest>=3.0.0', 'pytest-cov', 'tox', 'mock', 'patch',
 ]
 
-if sys.version_info[:2] >= (3, 5):
+if sys.version_info[:2] >= (3, 5, 3):
     install_requires.extend([
         'aiohttp>=3.0.1', 'aiodns>=1.1.1',
     ])


### PR DESCRIPTION
aiohttp>=3.0.1 require python>=3.5.3 and can't be installed on version 3.5.2 or lower. 
https://github.com/aio-libs/aiohttp#requirements