### PR TITLE
Is pyOpenSSL needed for latest Python versions?

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,8 +23,10 @@ def get_readme():
 
 
 install_requires = [
-    'requests[security]>=2.18.4', 'prettyexc>=0.6.0',
-    'six>=1.10.0', 'python-dateutil>=2.6.1',
+    'requests>=2.18.4', 'requests[security]>=2.18.4;python_version<"3.6"',
+    'prettyexc>=0.6.0',
+    'six>=1.10.0',
+    'python-dateutil>=2.6.1',
     'pytz',
 ]
 tests_require = [


### PR DESCRIPTION
I believe that requests library with the security extras are not needed for the latest Python versions: https://pyopenssl.org/en/stable/introduction.html#history

pipenv for example has this in its `setup.py`: `'requests[security];python_version<"2.7"'`